### PR TITLE
Fix equipment set filter on retail WoW

### DIFF
--- a/src/filters/EquipmentSet.lua
+++ b/src/filters/EquipmentSet.lua
@@ -27,14 +27,24 @@ local itemCache = {}
 
 --
 
+local SafeUnpackItemLocation
+
+if AddOn:IsRetailWow() then
+    SafeUnpackItemLocation = function(packedLoc)
+        local player, bank, bags, _, slot, bag = UnpackItemLocation(packedLoc)
+        return player, bank, bags, slot, bag
+    end
+else
+    SafeUnpackItemLocation = function(packedLoc)
+        return UnpackItemLocation(packedLoc)
+    end
+end
+
 local function UpdateItemsCache()
     wipe(itemCache)
     for _, setId in ipairs(GetEquipmentSetIDs()) do
         for _, packedLoc in pairs(GetItemLocations(setId)) do
-            local player, bank, bags, slot, bag = UnpackItemLocation(packedLoc)
-            -- NOTE: unlike documented, this method in Cataclysm Classic
-            -- no longer returns the voidstorage field between bags and slot.
-            -- TODO: requires additional testing on retail!
+            local player, bank, bags, slot, bag = SafeUnpackItemLocation(packedLoc)
 
             if bank then
                 bag = BANK_CONTAINER


### PR DESCRIPTION
This should fix #127

On retail, the `UnpackItemLocation` API function still returns a flag for items in void storage.