### PR TITLE
Fixed error preventing context menu from opening

### DIFF
--- a/Baggins.lua
+++ b/Baggins.lua
@@ -4379,11 +4379,7 @@ local function EasyMenu_Initialize(frame, level, menuList)
 end
 
 function Baggins:EasyMenu(menuList, menuFrame, anchor, x, y, displayMode, autoHideDelay)
-    if Baggins:IsRetailWow() then
-        if displayMode=='MENU' then menuFrame.displayMode = displayMode end
-        UIDropDownMenu_Initialize(menuFrame, EasyMenu_Initialize, displayMode, nil, menuList)
-        ToggleDropDownMenu(1, nil, menuFrame, anchor, x, y, menuList, nil, autoHideDelay)
-    else
-        EasyMenu(menuList, menuFrame, anchor, x, y, displayMode, autoHideDelay)
-    end
+    if displayMode=='MENU' then menuFrame.displayMode = displayMode end
+    UIDropDownMenu_Initialize(menuFrame, EasyMenu_Initialize, displayMode, nil, menuList)
+    ToggleDropDownMenu(1, nil, menuFrame, anchor, x, y, menuList, nil, autoHideDelay)
 end


### PR DESCRIPTION
They took away easymenu on cata in the latest patch. Similar to https://github.com/doadin/Baggins/issues/128.

Quick fix to do it the retail way looks like it works.