### PR TITLE
fix getCompressAll nil value

### DIFF
--- a/Baggins-Options.lua
+++ b/Baggins-Options.lua
@@ -731,7 +731,7 @@ local function refresh()
     Baggins:Baggins_RefreshBags()
 end
 
-local function getCompressAll()
+function Baggins:getCompressAll()
     return Baggins.db.profile.compressall
 end
 

--- a/bindings.xml
+++ b/bindings.xml
@@ -7,14 +7,15 @@
 	</Binding>
 	<Binding name="BAGGINS_TOGGLECOMPRESSALL" category="Baggins">
 		if Baggins:getCompressAll() then
-		    Baggins.db.profile.compressall = false
-			self:RebuildSectionLayouts()
-			self:Baggins_RefreshBags()
-		end
-		if not Baggins:getCompressAll() then
-		    Baggins.db.profile.compressall = true
-			self:RebuildSectionLayouts()
-			self:Baggins_RefreshBags()
+			Baggins.db.profile.compressall = false
+			Baggins:RebuildSectionLayouts()
+			Baggins:Baggins_RefreshBags()
+			Baggins:ReallyUpdateBags()
+		else
+			Baggins.db.profile.compressall = true
+			Baggins:RebuildSectionLayouts()
+			Baggins:Baggins_RefreshBags()
+			Baggins:ReallyUpdateBags()
 		end
 	</Binding>
 </Bindings>


### PR DESCRIPTION
Hello. Thank you for implementing this feature. I only just noticed you added it and hadn't tested it until now 🥲

I get the following error when I try to run the keyboard shortcut.

So I've made a change to fix it.

```
1x [string "BAGGINS_TOGGLECOMPRESSALL"]:1: attempt to call method 'getCompressAll' (a nil value)
[BAGGINS_TOGGLECOMPRESSALL]:1: in function <[string "BAGGINS_TOGGLECOMPRESSALL"]:1>

Locals:
keystate = "down"
(*temporary) = nil
(*temporary) = <table> {
 cannotDetachTooltip = true
 modules = <table> {
 }
 defaultcategories = <table> {
 }
 defaultModuleState = true
 minSpareItemButtons = 10
 doInitialBankUpdate = true
 hasIcon = "Interface\Icons\INV_Jewelry_Ring_03"
 editOpts = <table> {
 }
 ptsetsdirty = false
 obj = <table> {
 }
 hooks = <table> {
 }
 currentSkin = <table> {
 }
 itemcounts = <table> {
 }
 independentProfile = true
 sectionOrderDirty = true
 doInitialUpdate = true
 OnMenuRequest = <table> {
 }
 opts = <table> {
 }
 db = <table> {
 }
 colors = <table> {
 }
 baseName = "Baggins"
 enabledState = true
 clickableTooltip = true
 bagframes = <table> {
 }
 name = "Baggins"
 defaultModuleLibraries = <table> {
 }
 hideWithoutStandby = true
 orderedModules = <table> {
 }
}
(*temporary) = "attempt to call method 'getCompressAll' (a nil value)"

```